### PR TITLE
enable horizontal scroll on options

### DIFF
--- a/src/components/ButtonRow/ButtonRow.module.css
+++ b/src/components/ButtonRow/ButtonRow.module.css
@@ -1,2 +1,4 @@
 .buttonRow {
+    /* Remove line-wrap to allow for horizontal scrolling */
+    white-space: nowrap;
 }

--- a/src/components/ControlPane/ControlPane.module.css
+++ b/src/components/ControlPane/ControlPane.module.css
@@ -10,12 +10,19 @@
     to deal with it yet!
   */
   margin-bottom: 32px;
+  /* Scrolling when the options can't fit in the same line */
+  overflow-x: auto;
 }
 
 .title {
   margin: 0;
   /* Optical centering */
   margin-bottom: -4px;
+  padding-bottom: 16px;
+
+  /* Make the title immune to horizontal scroll */
+  position: sticky;
+  left: 0;
 }
 
 .metadata {


### PR DESCRIPTION
[Exercise 3](https://github.com/VrsajkovIvan33/character-creator?tab=readme-ov-file#exercise-3-overflow)

Add horizontal scrolling for options when they can't fit in a single line. 

Use `position: sticky` for the title to anchor it to the left.