### PR TITLE
set grey background bar

### DIFF
--- a/src/components/CharacterEditor/CharacterEditor.js
+++ b/src/components/CharacterEditor/CharacterEditor.js
@@ -30,6 +30,8 @@ function App() {
 
   return (
     <main className={styles.characterEditor}>
+      <div className={styles.backgroundBar}></div>
+
       <MaxWidthWrapper className={styles.maxWidthWrapper}>
         <header className={styles.header}>
           <h1 className={styles.title}>Create your Character</h1>

--- a/src/components/CharacterEditor/CharacterEditor.module.css
+++ b/src/components/CharacterEditor/CharacterEditor.module.css
@@ -3,7 +3,9 @@
   padding-bottom: 64px;
 }
 
-.maxWidthWrapper {}
+.maxWidthWrapper {
+  position: relative;
+}
 
 .header {
   padding-bottom: 64px;
@@ -33,4 +35,12 @@
 
 .controlColumn {
   width: 50%;
+}
+
+.backgroundBar {
+  position: fixed;
+  bottom: 0;
+  height: 40%;
+  width: 100%;
+  background-color: hsl(195deg, 20%, 86%);
 }


### PR DESCRIPTION
[Exercise 4](https://github.com/VrsajkovIvan33/character-creator?tab=readme-ov-file#exercise-4-perspective-decoration)

Add grey background in the lower 40% of the screen.

Use DOM order to manage overlap instead of z-index. To do that, we add `position: relative;` to MaxWidthWrapper.