### PR TITLE
fix overflow styles

### DIFF
--- a/src/components/ButtonRow/ButtonRow.module.css
+++ b/src/components/ButtonRow/ButtonRow.module.css
@@ -1,4 +1,11 @@
 .buttonRow {
-    /* Remove line-wrap to allow for horizontal scrolling */
+    /* Horizontal scrolling */
+    overflow-x: auto;
     white-space: nowrap;
+
+    /* Move scroller further away from element */
+    /* -> Increase padding and negate it with negative margin */
+    /* 22 vs 24 -> leave 2px of space on left and right when scrolling */
+    padding: 24px 22px;
+    margin: 0 -22px -24px -22px;
 }

--- a/src/components/ControlPane/ControlPane.module.css
+++ b/src/components/ControlPane/ControlPane.module.css
@@ -10,19 +10,12 @@
     to deal with it yet!
   */
   margin-bottom: 32px;
-  /* Scrolling when the options can't fit in the same line */
-  overflow-x: auto;
 }
 
 .title {
   margin: 0;
   /* Optical centering */
   margin-bottom: -4px;
-  padding-bottom: 16px;
-
-  /* Make the title immune to horizontal scroll */
-  position: sticky;
-  left: 0;
 }
 
 .metadata {


### PR DESCRIPTION
[When solving Exercise 3](https://github.com/VrsajkovIvan33/character-creator/pull/4), we set the scroll on the entire `ControlPane` component and used `position: sticky;` on the title to make it not move around. This enabled us to have a scroller set in the position [as in the exercise specification](https://github.com/VrsajkovIvan33/character-creator?tab=readme-ov-file#exercise-3-overflow).

As a side effect, the title would move together with the scrollable options when the side of the scroller as an effect of reaching the end of the possible scrolling.

To fix it, we use the same approach as presented in the exercise solution: set the scroller in the `ButtonRow` component, _move the scroller away_ from the options with **padding** and then re-adjust the layout using **negative margins**. This also allows us to leave the 2px white space between the scrolling options and the left boundary of `ControlPane`.